### PR TITLE
profile picture added

### DIFF
--- a/server/src/main/java/com/server/controllers/UserController.java
+++ b/server/src/main/java/com/server/controllers/UserController.java
@@ -17,34 +17,15 @@ public class UserController {
     @Autowired
     private UserService userService;
 
-    // Register a new user
-    @PostMapping("/register")
-    public ResponseEntity<?> registerUser(@RequestBody User user) {
-        try {
-            User savedUser = userService.saveUser(user);
-            return ResponseEntity.ok("User registered successfully!");
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
+    //Check with localhost:8080/api/users/{{id}}/profile-picture?url="link to image here"
+    @PatchMapping("/{id}/profile-picture")
+    public ResponseEntity<?> updateProfilePicture(@PathVariable String id, @RequestParam String url){
+        Optional<User> updateUser = userService.updateProfilePicture(id,url);
+        if (updateUser.isPresent()){
+            return ResponseEntity.ok("Profile Picture updated successfully");
+        } else {
+            return ResponseEntity.notFound().build();
         }
-    }
-
-    // Login endpoint
-    @PostMapping("/login")
-    public ResponseEntity<?> loginUser(@RequestBody Map<String, String> loginData) {
-        String username = loginData.get("username");
-        String password = loginData.get("password");
-
-        Optional<User> optionalUser = userService.findByUsername(username);
-        if (optionalUser.isEmpty()) {
-            return ResponseEntity.status(401).body("Invalid username or password");
-        }
-
-        User user = optionalUser.get();
-        if (!userService.checkPassword(password, user.getPassword())) {
-            return ResponseEntity.status(401).body("Invalid username or password");
-        }
-
-        return ResponseEntity.ok("Login successful!");
     }
 
     // Get user by ID

--- a/server/src/main/java/com/server/models/User.java
+++ b/server/src/main/java/com/server/models/User.java
@@ -19,6 +19,9 @@ public class User {
 
     private String email;
 
+    //url link to the image
+    private String profilePicture;
+
     private String password;
 
     private int reputation = 0; // Default reputation when a user registers

--- a/server/src/main/java/com/server/repositories/UserRepository.java
+++ b/server/src/main/java/com/server/repositories/UserRepository.java
@@ -1,4 +1,4 @@
-package com.server.repository;
+package com.server.repositories;
 
 import com.server.models.User;
 import org.springframework.data.mongodb.repository.MongoRepository;

--- a/server/src/main/java/com/server/services/UserService.java
+++ b/server/src/main/java/com/server/services/UserService.java
@@ -1,7 +1,7 @@
 package com.server.services;
 
 import com.server.models.User;
-import com.server.repository.UserRepository;
+import com.server.repositories.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -31,10 +31,23 @@ public class UserService {
 
         // Encrypt password and assign default fields
         user.setPassword(passwordEncoder.encode(user.getPassword()));
+        user.setProfilePicture("https://imgur.com/hepj9ZS"); // this is a default userProfile for every user
         user.setRoles(Set.of("ROLE_USER")); // Default role
         user.setReputation(0); // Default reputation
 
         return userRepository.save(user);
+    }
+
+    //update profile picture of user
+    public Optional<User> updateProfilePicture(String userId,String profilepictureUrl){
+        Optional<User> user = userRepository.findById(userId);
+        if (user.isPresent()){
+            User existingUser = user.get();
+            existingUser.setProfilePicture(profilepictureUrl);
+            userRepository.save(existingUser);
+            return Optional.of(existingUser);
+        }
+        return Optional.empty();
     }
 
     // Check if the provided raw password matches the hashed password


### PR DESCRIPTION
## Changes made
- `User` model now has one more field, **profilePicture** to save the link of the user pfp
- Default picture for user added when creating a new user
- New patch endpoint created for updating userProfilePicture
- Removed redundant `api/users/login` and `api/users/register` endpoints, login and register are handled in the `auth/login` and `auth/register` endpoints