### PR TITLE
403 errors redirected to 404

### DIFF
--- a/server/src/main/java/com/server/config/SecurityConfig.java
+++ b/server/src/main/java/com/server/config/SecurityConfig.java
@@ -42,14 +42,12 @@ public class SecurityConfig {
         http.addFilterBefore(new JwtAuthFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
         http.authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("auth/register", "auth/login")
-                        .permitAll()
-                        .anyRequest()
-                        .authenticated())
+                        // Public endpoints
+                        .requestMatchers("/auth/register", "/auth/login").permitAll()
+                        // All other endpoints must be authenticated
+                        .anyRequest().authenticated())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(AbstractHttpConfigurer::disable);
-        //can use csrf((csrf)->disable()) instead of AbstractHttpConfigurer::disable
-        //doesn't change anything
 
         return http.build();
     }


### PR DESCRIPTION
### Previous Issue
Endpoints that dont exist used to return 403 errors when they were supposed to return 404 but with this PR now if any request with a valid token tries to access a non existing endpoint, spring returns 404 error. But for requests with no JWT, accessing any endpoint except the `auth/login` and `auth/register` still returns 403 error even if the endpoint doesn't exist because those two endpoints are the only public endpoints.

This doesn't have any major changes on how things operate it is just a small bug fix. 