### PR TITLE
jwt token from cookie to header

### DIFF
--- a/server/src/main/java/com/server/security/JwtAuthFilter.java
+++ b/server/src/main/java/com/server/security/JwtAuthFilter.java
@@ -50,9 +50,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     }
 
     private String extractToken(HttpServletRequest request) {
-        String header = request.getHeader("Authorization");
-        if (header != null && header.startsWith("Bearer ")) {;
-            return header.split(" ")[1];
+        String header = request.getHeader("jwt_token");
+        if (header != null  ) {;
+            return header;
         }
 
         if (request.getCookies() != null){


### PR DESCRIPTION
Jwt token is now passed as a header, not as a cookie as it was once before.